### PR TITLE
Character names

### DIFF
--- a/shin-core/src/layout/layouter.rs
+++ b/shin-core/src/layout/layouter.rs
@@ -454,7 +454,8 @@ pub fn layout_text(params: LayoutParams, text: &str) -> LayoutedMessage {
     let layout_mode = layouter.params.mode;
     match layout_mode {
         LayoutingMode::MessageText => {
-            // Character names are 0.9 font size in message boxes
+            // Character names are 0.9 font size in message boxes, and displayed instantly
+            layouter.state.instant = true;
             layouter.state.font_size = 0.9;
         }
         _ => {}

--- a/shin-core/src/layout/layouter.rs
+++ b/shin-core/src/layout/layouter.rs
@@ -501,6 +501,8 @@ pub fn layout_text(params: LayoutParams, text: &str) -> LayoutedMessage {
                     // If it was false in the first place, just do a normal newline.
                     if character_name {
                         layouter.on_newline(false); // No line wrapping in the character name
+
+                        // We are finishing the character name part, so reset the instant state and font size to the normal values
                         layouter.state.instant = false;
                         layouter.state.font_size = 1.0;
                         character_name = false

--- a/shin-core/src/layout/mod.rs
+++ b/shin-core/src/layout/mod.rs
@@ -3,6 +3,6 @@ mod parser;
 
 pub use layouter::{
     layout_text, Action, ActionType, Block, BlockExitCondition, LayoutParams, LayoutedChar,
-    LayoutedMessage, LayouterState, MessageMetrics,
+    LayoutedMessage, LayouterState, LayoutingMode,
 };
 pub use parser::{LayouterParser, ParsedCommand};

--- a/shin-core/src/layout/mod.rs
+++ b/shin-core/src/layout/mod.rs
@@ -3,6 +3,6 @@ mod parser;
 
 pub use layouter::{
     layout_text, Action, ActionType, Block, BlockExitCondition, LayoutParams, LayoutedChar,
-    LayoutedMessage, LayouterState,
+    LayoutedMessage, LayouterState, MessageMetrics,
 };
 pub use parser::{LayouterParser, ParsedCommand};

--- a/shin-core/src/vm/command/layer.rs
+++ b/shin-core/src/vm/command/layer.rs
@@ -287,7 +287,7 @@ impl FromVmCtx<NumberSpec> for LayerProperty {
 pub enum MessageboxType {
     Neutral = 0,
     WitchSpace = 1,
-    Ushinomiya = 2,
+    Ushiromiya = 2,
     Transparent = 3,
     Novel = 4,
     NoText = 5,

--- a/shin/src/layer/message_layer/messagebox.rs
+++ b/shin/src/layer/message_layer/messagebox.rs
@@ -204,7 +204,7 @@ impl Renderable for Messagebox {
         let texture = match self.messagebox_type {
             MessageboxType::Neutral => &self.textures.message_window_1,
             MessageboxType::WitchSpace => &self.textures.message_window_2,
-            MessageboxType::Ushinomiya => &self.textures.message_window_3,
+            MessageboxType::Ushiromiya => &self.textures.message_window_3,
             MessageboxType::Transparent => {
                 todo!()
             }

--- a/shin/src/layer/message_layer/messagebox.rs
+++ b/shin/src/layer/message_layer/messagebox.rs
@@ -32,8 +32,15 @@ pub struct MessageboxTextures {
 const MAX_VERTEX_COUNT: usize = 120;
 const TEX_SIZE: Vector2<f32> = Vector2::new(1648.0, 288.0);
 
+// https://stackoverflow.com/a/34324856
+macro_rules! count {
+    () => (0usize);
+    ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
+}
+
 macro_rules! make_vertices {
-    ($r:expr, $([$x:expr, $y:expr, $x_tex:expr, $y_tex: expr]),*) => {
+    ($r:expr, $([$x:expr, $y:expr, $x_tex:expr, $y_tex:expr]),*) => {
+        $r.reserve(count!($($x)*));
         $(
             $r.push(PosColTexVertex {
                 position: Vector3::new($x, $y, 1.0),
@@ -49,7 +56,6 @@ fn build_message_header_buffer(character_name_width: f32) -> Vec<PosColTexVertex
 
     if character_name_width == 0.0 {
         // Draw the header part without a character name box
-        result.reserve(8);
         make_vertices!(
             result,
             [130.0, -32.0, 0.0, 144.0],
@@ -63,7 +69,6 @@ fn build_message_header_buffer(character_name_width: f32) -> Vec<PosColTexVertex
         );
     } else {
         // Draw the header part with a character name box
-        result.reserve(12);
         make_vertices!(
             result,
             [130.0, -32.0, 0.0, 0.0],
@@ -86,7 +91,6 @@ fn build_message_header_buffer(character_name_width: f32) -> Vec<PosColTexVertex
 
 fn build_message_body_vertices(height: f32) -> Vec<PosColTexVertex> {
     let mut result = Vec::new();
-    result.reserve(13);
 
     let mid = height + 32.0 - 256.0;
     let high = height + 32.0;

--- a/shin/src/layer/message_layer/messagebox.rs
+++ b/shin/src/layer/message_layer/messagebox.rs
@@ -3,9 +3,10 @@ use crate::asset::texture_archive::TextureArchive;
 use crate::render::{GpuCommonResources, PosColTexVertex, Renderable, VertexBuffer};
 use crate::update::{Updatable, UpdateContext};
 use cgmath::{Matrix4, Vector2, Vector3, Vector4};
-use shin_core::layout::MessageMetrics;
 use shin_core::vm::command::layer::MessageboxType;
 use std::sync::Arc;
+
+use super::MessageMetrics;
 
 #[derive(TextureArchive)]
 pub struct MessageboxTextures {

--- a/shin/src/layer/message_layer/mod.rs
+++ b/shin/src/layer/message_layer/mod.rs
@@ -341,7 +341,6 @@ impl MessageLayer {
 
         let message = Message::new(
             context,
-            // TODO: actually reuse the atlas
             self.font_atlas.clone(),
             Vector2::new(-740.0 - 9.0, 300.0 - 83.0),
             text,


### PR DESCRIPTION
Implements layouting and messagebox header display for character names in lines:
![image](https://user-images.githubusercontent.com/102922815/211155499-404db638-e43d-480c-b01e-058abd488f04.png)

Apart from this, the `MessageMetrics` struct I added (to copy the character name width from the layouter to the message box) also includes a field for the message height, which should make it easy to scale the message box for tall messages in the future.

Let me know if you want anything renamed or restructured!