### PR TITLE
Allow pressing F10 to (re)set the window size to 1920x1080

### DIFF
--- a/shin/src/window.rs
+++ b/shin/src/window.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tracing::{debug, info, trace, warn};
 
-use winit::dpi::{LogicalPosition, LogicalSize};
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use winit::window::Fullscreen;
 use winit::{
     event::*,
@@ -445,6 +445,15 @@ pub async fn run() {
                                     .map_or_else(|| Some(Fullscreen::Borderless(None)), |_| None),
                             );
                         }
+                        WindowEvent::KeyboardInput {
+                            input:
+                                KeyboardInput {
+                                    state: ElementState::Pressed,
+                                    virtual_keycode: Some(VirtualKeyCode::F10),
+                                    ..
+                                },
+                            ..
+                        } => window.set_inner_size(PhysicalSize::new(1920, 1080)),
                         WindowEvent::Resized(physical_size) => {
                             state.resize((*physical_size).into());
                         }


### PR DESCRIPTION
This is useful e.g. when comparing the game's output to that of the switch game. I thought F10 is the most fitting key because it's next to F11 (fullscreen), and also because of "**10**80p" I guess 😅 Let me know if you would prefer a different key.