### PR TITLE
Parse remaining SNR info tables

### DIFF
--- a/sdu/src/main.rs
+++ b/sdu/src/main.rs
@@ -511,6 +511,14 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
                     i, item.bgm_id, item.name_index, item.once_flag
                 )?;
             }
+            writeln!(output, "Character Box Segments:")?;
+            for (i, item) in tables.character_box_info.iter().enumerate() {
+                writeln!(
+                    output,
+                    "  {}: {:?}",
+                    i, item
+                )?;
+            }
             writeln!(output, "Tips:")?;
             for (i, tip) in tables.tips_info.iter().enumerate() {
                 writeln!(

--- a/sdu/src/main.rs
+++ b/sdu/src/main.rs
@@ -513,11 +513,15 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
             }
             writeln!(output, "Character Box Segments:")?;
             for (i, item) in tables.character_box_info.iter().enumerate() {
-                writeln!(
-                    output,
-                    "  {}: {:?}",
-                    i, item
-                )?;
+                writeln!(output, "  {}: {:?}", i, item)?;
+            }
+            writeln!(output, "Character Sprites:")?;
+            for (i, item) in tables.chars_sprite_info.iter().enumerate() {
+                writeln!(output, "  {}: {:?} {:?}", i, item.unk1, item.segments)?;
+            }
+            writeln!(output, "Character Grids:")?;
+            for (i, item) in tables.chars_grid_info.iter().enumerate() {
+                writeln!(output, "  {}: {:?}", i, item.segments)?;
             }
             writeln!(output, "Tips:")?;
             for (i, tip) in tables.tips_info.iter().enumerate() {

--- a/sdu/src/main.rs
+++ b/sdu/src/main.rs
@@ -484,7 +484,7 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
                 writeln!(
                     output,
                     "  {}: {:?} {:?} {:?}",
-                    i, bgm.name, bgm.display_name, bgm.unk1
+                    i, bgm.name, bgm.display_name, bgm.linked_bgm_id
                 )?;
             }
             writeln!(output, "Ses:")?;

--- a/sdu/src/main.rs
+++ b/sdu/src/main.rs
@@ -499,16 +499,16 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
             for (_, mapping) in tables.voice_mapping_info.iter().enumerate() {
                 writeln!(output, "  {:?}: {:?}", mapping.name_prefix, mapping.unk1)?;
             }
-            writeln!(output, "VSection64:")?;
-            for (i, item) in tables.section64_info.iter().enumerate() {
-                writeln!(output, "  {}: {:?} {:?}", i, item.unk1, item.unk2)?;
+            writeln!(output, "Picture Box Entries:")?;
+            for (i, item) in tables.picture_box_info.iter().enumerate() {
+                writeln!(output, "  {}: {:?} {:?}", i, item.name, item.picture_ids)?;
             }
-            writeln!(output, "VSection68:")?;
-            for (i, item) in tables.section68_info.iter().enumerate() {
+            writeln!(output, "Music Box Entries:")?;
+            for (i, item) in tables.music_box_info.iter().enumerate() {
                 writeln!(
                     output,
                     "  {}: {:?} {:?} {:?}",
-                    i, item.unk1, item.unk2, item.unk3
+                    i, item.bgm_id, item.name_index, item.once_flag
                 )?;
             }
             writeln!(output, "Tips:")?;

--- a/sdu/src/main.rs
+++ b/sdu/src/main.rs
@@ -465,14 +465,18 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
             }
             writeln!(output, "Pictures:")?;
             for (i, picture) in tables.picture_info.iter().enumerate() {
-                writeln!(output, "  {}: {:?} {:?}", i, picture.name, picture.unk1)?;
+                writeln!(
+                    output,
+                    "  {}: {:?} {:?}",
+                    i, picture.name, picture.linked_cg_id
+                )?;
             }
             writeln!(output, "Bustups:")?;
             for (i, bustup) in tables.bustup_info.iter().enumerate() {
                 writeln!(
                     output,
                     "  {}: {:?} {:?} {:?}",
-                    i, bustup.name, bustup.emotion, bustup.unk1
+                    i, bustup.name, bustup.emotion, bustup.lipsync_character_id
                 )?;
             }
             writeln!(output, "Bgms:")?;
@@ -492,12 +496,16 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
                 writeln!(
                     output,
                     "  {}: {:?} {:?} {:?} {:?}",
-                    i, movie.name, movie.unk1, movie.unk2, movie.unk3
+                    i, movie.name, movie.linked_picture_id, movie.flags, movie.linked_picture_id
                 )?;
             }
             writeln!(output, "Voice Mappings:")?;
             for (_, mapping) in tables.voice_mapping_info.iter().enumerate() {
-                writeln!(output, "  {:?}: {:?}", mapping.name_prefix, mapping.unk1)?;
+                writeln!(
+                    output,
+                    "  {:?}: {:?}",
+                    mapping.name_pattern, mapping.lipsync_character_ids
+                )?;
             }
             writeln!(output, "Picture Box Entries:")?;
             for (i, item) in tables.picture_box_info.iter().enumerate() {
@@ -517,7 +525,7 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
             }
             writeln!(output, "Character Sprites:")?;
             for (i, item) in tables.chars_sprite_info.iter().enumerate() {
-                writeln!(output, "  {}: {:?} {:?}", i, item.unk1, item.segments)?;
+                writeln!(output, "  {}: {:?} {:?}", i, item.episode, item.segments)?;
             }
             writeln!(output, "Character Grids:")?;
             for (i, item) in tables.chars_grid_info.iter().enumerate() {
@@ -528,7 +536,7 @@ fn scenario_command(command: ScenarioCommand) -> Result<()> {
                 writeln!(
                     output,
                     "  {}: {:?} {:?} {:?} {:?}",
-                    i, tip.unk1, tip.unk2, tip.unk3, tip.unk4
+                    i, tip.episode, tip.title_index, tip.title, tip.content
                 )?;
             }
 

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -88,19 +88,19 @@ pub struct VoiceMappingInfoItem {
 pub type VoiceMappingInfo = Vec<VoiceMappingInfoItem>;
 
 #[derive(Debug, BinRead, BinWrite)]
-pub struct Section64InfoItem {
-    pub unk1: U16String,
-    pub unk2: U16List<u16>,
+pub struct PictureBoxInfoItem {
+    pub name: U16String,
+    pub picture_ids: U16List<u16>,
 }
-pub type Section64Info = Vec<Section64InfoItem>;
+pub type PictureBoxInfo = Vec<PictureBoxInfoItem>;
 
 #[derive(Debug, BinRead, BinWrite)]
-pub struct Section68InfoItem {
-    pub unk1: u16,
-    pub unk2: u16,
-    pub unk3: u16,
+pub struct MusicBoxInfoItem {
+    pub bgm_id: u16,
+    pub name_index: u16,
+    pub once_flag: u16,
 }
-pub type Section68Info = Vec<Section68InfoItem>;
+pub type MusicBoxInfo = Vec<MusicBoxInfoItem>;
 
 #[derive(Debug, BinRead, BinWrite)]
 pub struct TipsInfoItem {
@@ -164,9 +164,9 @@ pub struct ScenarioInfoTables {
     #[br(parse_with = parse_sized_section_ptr)]
     pub voice_mapping_info: VoiceMappingInfo,
     #[br(parse_with = parse_simple_section_ptr)]
-    pub section64_info: Section64Info,
+    pub picture_box_info: PictureBoxInfo,
     #[br(parse_with = parse_simple_section_ptr)]
-    pub section68_info: Section68Info,
+    pub music_box_info: MusicBoxInfo,
     // I don't know how to parse these sections yet
     pub offset_72: u32,
     pub offset_76: u32,

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -224,6 +224,95 @@ pub struct CharsSpriteInfoItem {
 
 pub type CharsSpriteInfo = Vec<CharsSpriteInfoItem>;
 
+/// Defines how a `chars` grid portrait is displayed and behaves on Execute/Resurrect.
+#[derive(Debug, BinRead, BinWrite)]
+#[brw(repr = u8)]
+pub enum CharsGridPortraitBehavior {
+    /// Only an empty frame will be displayed, with no portrait inside.
+    EmptyFrame = 0,
+
+    /// If in game, the character will be shown as alive (in full colour). If out of game, the character can be switched between two phases: alive and dead.
+    AliveOrTwoPhase = 1,
+
+    /// If in game, the character will be shown as dead (in red); the associated sprite will be shown in greyscale with a **small** blood splotch. If out of game, the character can be switched between three phases: alive, missing (grayscale), and dead.
+    DeadOrThreePhase = 2,
+
+    /// If in game, the character will be shown as dead (in red); the associated sprite will be shown in greyscale with a **large** blood splotch. If out of game, behaves identically to `AliveOrTwoPhase`.
+    VeryDead = 3,
+}
+
+#[derive(Debug, BinRead, BinWrite)]
+#[brw(repr = u8)]
+pub enum CharsGridPortraitBehaviorModifier {
+    Unk0 = 0,
+    Unk1 = 1,
+}
+
+/// The shape of an individual connector between portraits in the `chars` grid.
+#[derive(Debug, BinRead, BinWrite)]
+#[brw(repr = u8)]
+pub enum CharsGridConnectorShape {
+    /// No connector is displayed.
+    None = 0,
+
+    /// `╴`: a line segment only on the left side.
+    LeftDeadEnd = 1,
+
+    /// `╵`: a line segment only on the top.
+    TopDeadEnd = 2,
+
+    /// `┘`: an elbow with lines facing towards the left side and the top.
+    LeftTopElbow = 3,
+
+    /// `╶`: a line segment only on the right side.
+    RightDeadEnd = 4,
+
+    /// `─`: a line from left to right.
+    HorizontalLine = 5,
+
+    /// `└`: an elbow with lines facing towards the top and the right side.
+    TopRightElbow = 6,
+
+    /// `┴`: a T with its orthogonal segment pointing towards the top.
+    TopPointingT = 7,
+
+    /// `╷`: a line segment only on the bottom.
+    BottomDeadEnd = 8,
+
+    /// `┐`: an elbow with lines facing towards the bottom and the left side.
+    BottomLeftElbow = 9,
+
+    /// `│`: a line from top to bottom.
+    VerticalLine = 10,
+
+    /// `┤`: a T with its orthogonal segment pointing towards the left side.
+    LeftPointingT = 11,
+
+    /// `┌`: an elbow with lines facing towards the right side and the bottom.
+    RightBottomElbow = 12,
+
+    /// `┬`: a T with its orthogonal segment pointing towards the bottom.
+    BottomPointingT = 13,
+
+    /// `├`: a T with its orthogonal segment pointing towards the right side.
+    RightPointingT = 14,
+
+    /// `┼`: a cross with line segments pointing to all four sides.
+    Cross = 15,
+
+    /// A vertical line, but displayed darker than usual. (This is never used in the game and might just be a failure mode of the engine for out-of-bounds shapes)
+    DarkVerticalLine = 16,
+}
+
+/// The color of an individual connector between portraits in the `chars` grid.
+#[derive(Debug, BinRead, BinWrite)]
+#[brw(repr = u8)]
+pub enum CharsGridConnectorColor {
+    Red = 1,
+    Blue = 2,
+    Yellow = 3,
+}
+
 /// An individual instruction for building the data underlying the grid in the Characters screen (`chars`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharsGridSegment {
@@ -242,13 +331,11 @@ pub enum CharsGridSegment {
         /// The ID of the character this portrait is for, indexing into [`CharsSpriteInfo`].
         character_id: u16,
 
-        /// Defines how the portrait and the corresponding sprite is displayed, and how it behaves on Execute/Resurrect:
-        ///  - **in game**: `0` = empty portrait, `1` = alive, `2` = dead (small blood splotch on sprite), `3` = very dead (large blood splotch on sprite)
-        ///  - **out of game** (Characters screen selected from main menu): `0` = empty portrait, `1` = two phases (alive/dead), `2` = three phases (alive/missing/dead)
-        behaviour: u8,
+        /// Defines how the portrait and the corresponding sprite is displayed, and how it behaves on Execute/Resurrect.
+        behavior: CharsGridPortraitBehavior,
 
         /// Modifies the `behaviour` in certain circumstances.
-        behaviour_modifier: u8, // todo: find out and document what this does
+        behavior_modifier: CharsGridPortraitBehaviorModifier, // todo: find out and document what this does
     },
 
     /// Defines an individual line segment to be placed on the grid, to connect character portraits.
@@ -263,28 +350,11 @@ pub enum CharsGridSegment {
         /// The connector's Y position on the grid.
         grid_y: u8,
 
-        /// The shape of this connector:
-        ///  - `0` = none
-        ///  - `1` = left dead end
-        ///  - `2` = top dead end
-        ///  - `3` = left-top elbow
-        ///  - `4` = right dead end
-        ///  - `5` = horizontal line
-        ///  - `6` = top-right elbow
-        ///  - `7` = T to the top
-        ///  - `8` = bottom dead end
-        ///  - `9` = bottom-left elbow
-        ///  - `10` = vertical line
-        ///  - `11` = T to the left
-        ///  - `12` = right-bottom elbow
-        ///  - `13` = T to the bottom
-        ///  - `14` = T to the right
-        ///  - `15` = cross
-        ///  - `16` = dark vertical line
-        shape: u8,
+        /// The shape of this connector.
+        shape: CharsGridConnectorShape,
 
-        /// The color of this connector: `1` = red, `2` = blue, `3` = yellow.
-        color: u8,
+        /// The color of this connector.
+        color: CharsGridConnectorColor,
     },
 }
 

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -102,6 +102,10 @@ pub struct MusicBoxInfoItem {
 }
 pub type MusicBoxInfo = Vec<MusicBoxInfoItem>;
 
+trait FinalSegment {
+    fn is_final(&self) -> bool;
+}
+
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharacterBoxSegment {
     /// Defines an individual background to be available for selection in the character box
@@ -111,7 +115,7 @@ pub enum CharacterBoxSegment {
         primary_picture_id: u16,
 
         /// This value is added to primary_picture_id to get the index of the secondary background image (shown behind the primary image). If 0, no secondary image will be shown.
-        secondary_picture_id_offset: u16
+        secondary_picture_id_offset: u16,
     },
 
     /// Defines an individual bustup to be available for selection in the character box
@@ -128,7 +132,7 @@ pub enum CharacterBoxSegment {
 
     /// Ends either the list of background definitions at the beginning, or ends an individual character definition, corresponding to a group of outfits (衣装)
     #[brw(magic = 0x22u8)]
-    EndDefinition
+    EndDefinition,
 }
 pub type CharacterBoxInfo = Vec<CharacterBoxSegment>;
 
@@ -141,11 +145,35 @@ pub enum CharsSpriteSegment {
     Segment0x1 { unk1: u8 },
 
     #[brw(magic = 0x2u8)]
-    Segment0x2 { unk1: u8, unk2: u8, unk3: U16String, unk4: U16String },
+    Segment0x2 {
+        unk1: u8,
+        unk2: u8,
+        unk3: U16String,
+        unk4: U16String,
+    },
 
     #[brw(magic = 0x3u8)]
-    Segment0x3 { unk1: U16String, unk2: U16String }
+    Segment0x3 { unk1: U16String, unk2: U16String },
 }
+
+impl FinalSegment for CharsSpriteSegment {
+    fn is_final(&self) -> bool {
+        match self {
+            CharsSpriteSegment::End => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, BinRead, BinWrite)]
+pub struct CharsSpriteInfoItem {
+    pub unk1: u8,
+
+    #[br(parse_with = parse_terminated_segment_list)]
+    pub segments: Vec<CharsSpriteSegment>,
+}
+
+pub type CharsSpriteInfo = Vec<CharsSpriteInfoItem>;
 
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharsGridSegment {
@@ -153,11 +181,41 @@ pub enum CharsGridSegment {
     End,
 
     #[brw(magic = 0x1u8)]
-    Portrait { page: u8, grid_x: u8, grid_y: u8, character_id: u16, behaviour: u8, behaviour_modifier: u8 },
+    Portrait {
+        page: u8,
+        grid_x: u8,
+        grid_y: u8,
+        character_id: u16,
+        behaviour: u8,
+        behaviour_modifier: u8,
+    },
 
-    #[brw(magic = 0x1u8)]
-    Connector { page: u8, grid_x: u8, grid_y: u8, shape: u8, color: u8 },
+    #[brw(magic = 0x2u8)]
+    Connector {
+        page: u8,
+        grid_x: u8,
+        grid_y: u8,
+        shape: u8,
+        color: u8,
+    },
 }
+
+impl FinalSegment for CharsGridSegment {
+    fn is_final(&self) -> bool {
+        match self {
+            CharsGridSegment::End => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, BinRead, BinWrite)]
+pub struct CharsGridInfoItem {
+    #[br(parse_with = parse_terminated_segment_list)]
+    pub segments: Vec<CharsGridSegment>,
+}
+
+pub type CharsGridInfo = Vec<CharsGridInfoItem>;
 
 #[derive(Debug, BinRead, BinWrite)]
 pub struct TipsInfoItem {
@@ -197,10 +255,33 @@ fn parse_sized_segment_list<R: Read + Seek, T: for<'a> BinRead<Args<'a> = ()> + 
     while reader.stream_position()? < initial_pos + byte_size as u64 {
         match T::read_options(reader, endian, ()) {
             Ok(segment) => result.push(segment),
-            Err(err) => return Err(err)
+            Err(err) => return Err(err),
         };
     }
     Ok(result)
+}
+
+fn parse_terminated_segment_list<
+    R: Read + Seek,
+    T: for<'a> BinRead<Args<'a> = ()> + FinalSegment + 'static,
+>(
+    reader: &mut R,
+    endian: Endian,
+    _: (),
+) -> BinResult<Vec<T>> {
+    let mut result = Vec::new();
+    loop {
+        match T::read_options(reader, endian, ()) {
+            Ok(segment) => {
+                let is_final = segment.is_final();
+                result.push(segment);
+                if is_final {
+                    return Ok(result);
+                }
+            }
+            Err(err) => return Err(err),
+        };
+    }
 }
 
 #[derive(Debug, BinRead)]
@@ -208,7 +289,7 @@ fn parse_sized_segment_list<R: Read + Seek, T: for<'a> BinRead<Args<'a> = ()> + 
 struct SizedSegmentList<T: for<'a> BinRead<Args<'a> = ()> + 'static> {
     byte_size: u32,
     #[br(parse_with = parse_sized_segment_list, args(byte_size))]
-    elements: Vec<T>,
+    segments: Vec<T>,
 }
 
 fn parse_simple_section_ptr<R: Read + Seek, T: for<'a> BinRead<Args<'a> = ()> + 'static>(
@@ -233,7 +314,7 @@ fn parse_sized_segment_list_ptr<R: Read + Seek, T: for<'a> BinRead<Args<'a> = ()
     endian: Endian,
     args: FilePtrArgs<()>,
 ) -> BinResult<Vec<T>> {
-    FilePtr32::<SizedSegmentList<T>>::parse(reader, endian, args).map(|x| x.elements)
+    FilePtr32::<SizedSegmentList<T>>::parse(reader, endian, args).map(|x| x.segments)
 }
 
 // parses the sections from offsets
@@ -259,9 +340,10 @@ pub struct ScenarioInfoTables {
     pub music_box_info: MusicBoxInfo,
     #[br(parse_with = parse_sized_segment_list_ptr)]
     pub character_box_info: CharacterBoxInfo,
-    pub offset_76: u32,
-    pub offset_80: u32,
-
+    #[br(parse_with = parse_sized_section_ptr)]
+    pub chars_sprite_info: CharsSpriteInfo,
+    #[br(parse_with = parse_sized_section_ptr)]
+    pub chars_grid_info: CharsGridInfo,
     #[br(parse_with = parse_sized_section_ptr)]
     pub tips_info: Vec<TipsInfoItem>,
 }

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -329,7 +329,7 @@ pub enum CharsGridConnectorColor {
 /// An individual instruction for building the data underlying the grid in the Characters screen (`chars`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharsGridSegment {
-    /// Defines a portrait on the grid, with a corresponding character to have its full sprite, name, and description shown when the portrait is selected.
+    /// Defines a portrait on the grid, showing its full sprite, name, and description when selected.
     #[brw(magic = 0x1u8)]
     Portrait {
         /// The page to show this portrait on, between 0 and 3 (both inclusive). The game will automatically generate as many pages as necessary for a specific grid.
@@ -354,7 +354,7 @@ pub enum CharsGridSegment {
     /// Defines an individual line segment to be placed on the grid, to connect character portraits.
     #[brw(magic = 0x2u8)]
     Connector {
-        /// The page to show this portrait on, between 0 and 3 (both inclusive). The game will automatically generate as many pages as necessary for a specific grid.
+        /// The page to show this connector on, between 0 and 3 (both inclusive). The game will automatically generate as many pages as necessary for a specific grid.
         page: u8,
 
         /// The connector's X position on the grid.

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -6,18 +6,18 @@ use binrw::file_ptr::FilePtrArgs;
 use binrw::{BinRead, BinResult, BinWrite, Endian, FilePtr32};
 use std::io::{Read, Seek};
 
-/// Represents a mask, a black and white image specifying a transition between two screens.
+/// References a mask, a black and white image specifying a transition between two screens.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct MaskInfoItem {
-    /// The name of the mask, corresponding to the filename that will be loaded when a transition is performed with this mask.
+    /// The internal name of the mask. Corresponds to the base filename of the `.msk` file the engine will load from the `mask/` directory when a transition with this mask is to be performed.
     pub name: U16String,
 }
 pub type MaskInfo = Vec<MaskInfoItem>;
 
-/// Represents a static picture (`.pic` file).
+/// References a static picture (`.pic` file).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct PictureInfoItem {
-    /// The name of the picture, corresponding to the filename that will be loaded when the picture is displayed.
+    /// The internal name of the picture. Corresponds to the base filename of the `.pic` file the engine will load from the `picture/` directory when the picture is to be displayed.
     pub name: U16String,
 
     /// The ID of a different picture that is to be unlocked in the Picture Box (`cgmode`) if this picture is displayed.
@@ -35,20 +35,20 @@ impl PictureInfoItem {
     }
 }
 
-/// Represents a particular state of a bustup, that is, a sprite composed from multiple replaceable parts.
+/// References a particular state of a bustup, that is, a sprite composed from multiple replaceable parts.
 ///
 /// In Saku, those parts are a base (character + outfit, without a face), an emotion/expression (the face except for the mouth), and lips (for lipsync).
 ///
-/// This struct specifically represents a combination of (base + emotion); the lip state is determined and stored separately, by the lipsync system.
+/// This struct specifically references a combination of (base + emotion); the lip state is determined and stored separately, by the lipsync system.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct BustupInfoItem {
-    /// The base filename of the bustup. This is the file that will be loaded when the bustup is shown.
+    /// The base filename of the bustup. When the bustup is shown, the engine will load the `.bup` file with this basename from the `bustup` directory, regardless of the referenced emotion.
     pub name: U16String,
 
-    /// The name of the emotion, to be selected from the emotions present in the bustup file.
+    /// The internal name of the emotion, to be selected from the emotions present in the bustup file.
     pub emotion: U16String,
 
-    /// The ID of the character represented by this bustup, for lipsync purposes: if a voice file with a matching `character_id` in its corresponding [`VoiceMappingInfoItem`] is played, lipsync will be performed on this bustup.
+    /// The ID of the character referenced by this bustup, for lipsync purposes: if a voice file with a matching `character_id` in its corresponding [`VoiceMappingInfoItem`] is played, lipsync will be performed on this bustup.
     pub lipsync_character_id: u16,
 }
 pub type BustupInfo = Vec<BustupInfoItem>;
@@ -59,13 +59,13 @@ impl BustupInfoItem {
     }
 }
 
-/// Represents the metadata for a background music (BGM) track.
+/// References a background music (BGM) track.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct BgmInfoItem {
-    /// The internal name of the BGM track, corresponding to the filename the engine will look for when playing the BGM.
+    /// The internal name of the BGM track. Corresponds to the base filename of the `.nxa` file the engine will load from the `bgm/` directory when the BGM is to be played.
     pub name: U16String,
 
-    /// The display name of the BGM track. This is the name the engine will show in the top left corner when the BGM is played. It does not affect the title displayed in the Music Box (`bgmmode`).
+    /// The display name of the BGM track. This is the name the engine will show in the top left corner when BGM playback starts. It does not affect the title displayed in the Music Box (`bgmmode`).
     pub display_name: U16String,
 
     pub unk1: u16, // BGM mode unlock id?
@@ -78,10 +78,10 @@ impl BgmInfoItem {
     }
 }
 
-/// Represents the metadata for a sound effect.
+/// References a sound effect (SE).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct SeInfoItem {
-    /// The name of this sound effect; simultaneously the filename the engine will look for when playing the sound effect.
+    /// The internal name of this sound effect. Corresponds to the base filename of the `.nxa` file the engine will load from the `se/` directory when the sound effect is to be played.
     pub name: U16String,
 }
 pub type SeInfo = Vec<SeInfoItem>;
@@ -92,10 +92,10 @@ impl SeInfoItem {
     }
 }
 
-/// Represents a movie, i.e. a video that can be played back by the engine. The engine makes no fundamental distinction between movies used for cutscenes (e.g. openings) and movies used for animation purposes.
+/// References a movie, i.e. a video that can be played back by the engine. The engine makes no fundamental distinction between movies used for cutscenes (e.g. openings) and movies used for animation purposes.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct MovieInfoItem {
-    /// The name of this movie; simultaneously the filename the engine will look for when playing back the movie.
+    /// The name of this movie. Corresponds to the base filename of the `.mp4` file the engine will load from the `movie/` directory when the movie is to be played.
     pub name: U16String,
 
     /// The ID of the picture that will be displayed instead of the movie after the movie has finished playing. This is only really relevant for movies used in animations; the movies used in cutscenes have this set to 0.

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -6,16 +6,26 @@ use binrw::file_ptr::FilePtrArgs;
 use binrw::{BinRead, BinResult, BinWrite, Endian, FilePtr32};
 use std::io::{Read, Seek};
 
+/// Represents a mask, a black and white image specifying a transition between two screens.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct MaskInfoItem {
+    /// The name of the mask, corresponding to the filename that will be loaded when a transition is performed with this mask.
     pub name: U16String,
 }
 pub type MaskInfo = Vec<MaskInfoItem>;
 
+/// Represents a static picture (`.pic` file).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct PictureInfoItem {
+    /// The name of the picture, corresponding to the filename that will be loaded when the picture is displayed.
     pub name: U16String,
-    pub unk1: i16, // CG mode unlock id?
+
+    /// The ID of a different picture that is to be unlocked in the Picture Box (`cgmode`) if this picture is displayed.
+    ///
+    /// This is needed because the game occasionally composes CGs dynamically out of multiple animated parts, but still wants the (static, pre-assembled) main CG picture to be unlocked in the Picture Box if its main part (i.e. this picture) is shown.
+    ///
+    /// If there is no linked picture, the value is `-1`.
+    pub linked_cg_id: i16,
 }
 pub type PictureInfo = Vec<PictureInfoItem>;
 
@@ -25,11 +35,21 @@ impl PictureInfoItem {
     }
 }
 
+/// Represents a particular state of a bustup, that is, a sprite composed from multiple replaceable parts.
+///
+/// In Saku, those parts are a base (character + outfit, without a face), an emotion/expression (the face except for the mouth), and lips (for lipsync).
+///
+/// This struct specifically represents a combination of (base + emotion); the lip state is determined and stored separately, by the lipsync system.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct BustupInfoItem {
+    /// The base filename of the bustup. This is the file that will be loaded when the bustup is shown.
     pub name: U16String,
+
+    /// The name of the emotion, to be selected from the emotions present in the bustup file.
     pub emotion: U16String,
-    pub unk1: u16, // character id for lipsync?
+
+    /// The ID of the character represented by this bustup, for lipsync purposes: if a voice file with a matching `character_id` in its corresponding [`VoiceMappingInfoItem`] is played, lipsync will be performed on this bustup.
+    pub lipsync_character_id: u16,
 }
 pub type BustupInfo = Vec<BustupInfoItem>;
 
@@ -39,10 +59,15 @@ impl BustupInfoItem {
     }
 }
 
+/// Represents the metadata for a background music (BGM) track.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct BgmInfoItem {
+    /// The internal name of the BGM track, corresponding to the filename the engine will look for when playing the BGM.
     pub name: U16String,
+
+    /// The display name of the BGM track. This is the name the engine will show in the top left corner when the BGM is played. It does not affect the title displayed in the Music Box (`bgmmode`).
     pub display_name: U16String,
+
     pub unk1: u16, // BGM mode unlock id?
 }
 pub type BgmInfo = Vec<BgmInfoItem>;
@@ -53,8 +78,10 @@ impl BgmInfoItem {
     }
 }
 
+/// Represents the metadata for a sound effect.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct SeInfoItem {
+    /// The name of this sound effect; simultaneously the filename the engine will look for when playing the sound effect.
     pub name: U16String,
 }
 pub type SeInfo = Vec<SeInfoItem>;
@@ -65,12 +92,20 @@ impl SeInfoItem {
     }
 }
 
+/// Represents a movie, i.e. a video that can be played back by the engine. The engine makes no fundamental distinction between movies used for cutscenes (e.g. openings) and movies used for animation purposes.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct MovieInfoItem {
+    /// The name of this movie; simultaneously the filename the engine will look for when playing back the movie.
     pub name: U16String,
-    pub unk1: u16,
-    pub unk2: u16,
-    pub unk3: i16,
+
+    /// The ID of the picture that will be displayed instead of the movie after the movie has finished playing. This is only really relevant for movies used in animations; the movies used in cutscenes have this set to 0.
+    pub linked_picture_id: u16,
+
+    /// A bitfield controlling the movie's exact playback behavior.
+    pub flags: u16, // todo: document meanings of bits
+
+    /// The ID of the BGM that will be unlocked in the Music Box if this movie is played back. This is only really relevant for cutscene movies, where the Music Box entry for an opening theme needs to be unlocked. If there is no linked BGM track, the value is `-1`.
+    pub linked_bgm_id: i16,
 }
 pub type MovieInfo = Vec<MovieInfoItem>;
 
@@ -80,24 +115,38 @@ impl MovieInfoItem {
     }
 }
 
+/// Matches a voice file to the lipsync character IDs for the characters speaking in the voice file, for lipsync purposes.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct VoiceMappingInfoItem {
-    pub name_prefix: U16String,
-    pub unk1: U8List<u8>, // character id list for lipsync?
+    /// A pattern of voice file paths to be matched to the list of character IDs; either an individual path or a wildcard pattern specified using `*`. Does not include the `voice/` prefix or the file extension.
+    pub name_pattern: U16String,
+
+    /// List of character IDs for which a bustup with a matching lipsync character ID in its [`BustupInfoItem`] should have its lips animated if it is currently being displayed while a voice file matching the pattern is being played back.
+    pub lipsync_character_ids: U8List<u8>,
 }
 pub type VoiceMappingInfo = Vec<VoiceMappingInfoItem>;
 
+/// An entry in the Picture Box (`cgmode`).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct PictureBoxInfoItem {
+    /// Internal name of the entry; defines the name of the texture to be loaded from `cgmode.txa` as the thumbnail for this entry.
     pub name: U16String,
+
+    /// List of picture IDs that will be shown in sequence as the player clicks through the entry.
     pub picture_ids: U16List<u16>,
 }
 pub type PictureBoxInfo = Vec<PictureBoxInfoItem>;
 
+/// An entry in the Music Box (`bgmmode`).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct MusicBoxInfoItem {
+    /// The ID of the BGM track to be played if this entry is selected.
     pub bgm_id: u16,
+
+    /// The index of the name to be displayed on the button for this entry, to be loaded from the `title*` textures in `bgmmode.txa`.
     pub name_index: u16,
+
+    /// If this flag is set to 1, the BGM track will play only once instead of looping at the end. This is used e.g. for opening themes.
     pub once_flag: u16,
 }
 pub type MusicBoxInfo = Vec<MusicBoxInfoItem>;
@@ -106,38 +155,41 @@ trait FinalSegment {
     fn is_final(&self) -> bool;
 }
 
+/// An individual instruction for building the data underlying the Character Box (`bupmode`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharacterBoxSegment {
-    /// Defines an individual background to be available for selection in the character box
+    /// Defines an individual background to be available for selection in the character box.
     #[brw(magic = 0x0u8)]
     Background {
-        /// The index of the picture that constitutes the primary background image (shown in front)
+        /// The index of the picture that constitutes the primary background image (shown in front).
         primary_picture_id: u16,
 
         /// This value is added to primary_picture_id to get the index of the secondary background image (shown behind the primary image). If 0, no secondary image will be shown.
         secondary_picture_id_offset: u16,
     },
 
-    /// Defines an individual bustup to be available for selection in the character box
+    /// Defines an individual bustup to be available for selection in the character box.
     #[brw(magic = 0x1u8)]
     Bustup { bustup_id: u16 },
 
-    /// Ends a group of facial expressions (表情)
+    /// Ends a group of facial expressions (表情).
     #[brw(magic = 0x2u8)]
     EndExpressionGroup,
 
-    /// Ends a group of poses (ポーズ)
+    /// Ends a group of poses (ポーズ).
     #[brw(magic = 0x12u8)]
     EndPoseGroup,
 
-    /// Ends either the list of background definitions at the beginning, or ends an individual character definition, corresponding to a group of outfits (衣装)
+    /// Ends either the list of background definitions at the beginning, or ends an individual character definition, corresponding to a group of outfits (衣装).
     #[brw(magic = 0x22u8)]
     EndDefinition,
 }
 pub type CharacterBoxInfo = Vec<CharacterBoxSegment>;
 
+/// An individual instruction for building the data underlying a character in the Characters screen (`chars`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharsSpriteSegment {
+    /// Ends the current character definition.
     #[brw(magic = 0x0u8)]
     End,
 
@@ -165,37 +217,83 @@ impl FinalSegment for CharsSpriteSegment {
     }
 }
 
+/// The data for a character in the Characters screen (`chars`)
 #[derive(Debug, BinRead, BinWrite)]
 pub struct CharsSpriteInfoItem {
-    pub unk1: u8,
+    /// The episode for which the character sprite and description is valid.
+    pub episode: u8,
 
+    /// The segments defining the sprites and description for this character.
     #[br(parse_with = parse_terminated_segment_list)]
     pub segments: Vec<CharsSpriteSegment>,
 }
 
 pub type CharsSpriteInfo = Vec<CharsSpriteInfoItem>;
 
+/// An individual instruction for building the data underlying the grid in the Characters screen (`chars`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharsGridSegment {
+    /// Ends the current character grid definition.
     #[brw(magic = 0x0u8)]
     End,
 
+    /// Defines a portrait on the grid, with a corresponding character to have its full sprite, name, and description shown when the portrait is selected.
     #[brw(magic = 0x1u8)]
     Portrait {
+        /// The page to show this portrait on, between 0 and 3 (both inclusive). The game will automatically generate as many pages as necessary for a specific grid.
         page: u8,
+
+        /// The portrait's X position on the grid.
         grid_x: u8,
+
+        /// The portrait's Y position on the grid.
         grid_y: u8,
+
+        /// The ID of the character this portrait is for, indexing into [`CharsSpriteInfo`].
         character_id: u16,
+
+        /// Defines how the portrait and the corresponding sprite is displayed, and how it behaves on Execute/Resurrect:
+        ///  - **in game**: `0` = empty portrait, `1` = alive, `2` = dead (small blood splotch on sprite), `3` = very dead (large blood splotch on sprite)
+        ///  - **out of game** (Characters screen selected from main menu): `0` = empty portrait, `1` = two phases (alive/dead), `2` = three phases (alive/missing/dead)
         behaviour: u8,
-        behaviour_modifier: u8,
+
+        /// Modifies the `behaviour` in certain circumstances.
+        behaviour_modifier: u8, // todo: find out and document what this does
     },
 
+    /// Defines an individual line segment to be placed on the grid, to connect character portraits.
     #[brw(magic = 0x2u8)]
     Connector {
+        /// The page to show this portrait on, between 0 and 3 (both inclusive). The game will automatically generate as many pages as necessary for a specific grid.
         page: u8,
+
+        /// The connector's X position on the grid.
         grid_x: u8,
+
+        /// The connector's Y position on the grid.
         grid_y: u8,
+
+        /// The shape of this connector:
+        ///  - `0` = none
+        ///  - `1` = left dead end
+        ///  - `2` = top dead end
+        ///  - `3` = left-top elbow
+        ///  - `4` = right dead end
+        ///  - `5` = horizontal line
+        ///  - `6` = top-right elbow
+        ///  - `7` = T to the top
+        ///  - `8` = bottom dead end
+        ///  - `9` = bottom-left elbow
+        ///  - `10` = vertical line
+        ///  - `11` = T to the left
+        ///  - `12` = right-bottom elbow
+        ///  - `13` = T to the bottom
+        ///  - `14` = T to the right
+        ///  - `15` = cross
+        ///  - `16` = dark vertical line
         shape: u8,
+
+        /// The color of this connector: `1` = red, `2` = blue, `3` = yellow.
         color: u8,
     },
 }
@@ -217,12 +315,20 @@ pub struct CharsGridInfoItem {
 
 pub type CharsGridInfo = Vec<CharsGridInfoItem>;
 
+/// An entry on the Tips screen (`tips`).
 #[derive(Debug, BinRead, BinWrite)]
 pub struct TipsInfoItem {
-    pub unk1: u8,
-    pub unk2: u16,
-    pub unk3: U16String,
-    pub unk4: U16String,
+    /// The episode this tip is for.
+    pub episode: u8,
+
+    /// The index of the title to be shown on the tip's selection button. Indexes into the `items` texture in `tips.txa`.
+    pub title_index: u16,
+
+    /// The textual title of this tip, to be shown in the headline above the content.
+    pub title: U16String,
+
+    /// The main content text.
+    pub content: U16String,
 }
 
 // types to parse the info sections

--- a/shin-core/src/format/scenario/info.rs
+++ b/shin-core/src/format/scenario/info.rs
@@ -162,7 +162,7 @@ pub type MusicBoxInfo = Vec<MusicBoxInfoItem>;
 /// An individual instruction for building the data underlying the Character Box (`bupmode`).
 #[derive(Debug, BinRead, BinWrite)]
 pub enum CharacterBoxSegment {
-    /// Defines an individual background to be available for selection in the character box.
+    /// Defines an individual background to be available for selection in the character box. The background will be shown behind the selected bustup.
     #[brw(magic = 0x0u8)]
     Background {
         /// The index of the picture (indexing into [`PictureInfo`]) that constitutes the primary background image (shown in front).
@@ -358,6 +358,9 @@ pub enum CharsGridSegment {
     },
 }
 
+/// A grid for the Characters screen (`chars`). Contains portraits which can be selected to reveal additional information about the character, and connectors making up lines between the portraits to show relationships between the characters.
+///
+/// The script can select a particular grid by ID to set it as the one that will be shown when opening `chars` from in-game. In addition, the first 8 grids are respectively the Episode 1-8 ones selectable from the main menu.
 #[derive(Debug, BinRead, BinWrite)]
 pub struct CharsGridInfoItem {
     #[br(parse_with = parse_terminated_segment_list)]

--- a/shin/src/adv/command/bgmplay.rs
+++ b/shin/src/adv/command/bgmplay.rs
@@ -22,7 +22,7 @@ impl StartableCommand for command::runtime::BGMPLAY {
         let bgm_info @ BgmInfoItem {
             name: _,
             display_name,
-            unk1: _,
+            linked_bgm_id: _,
         } = scenario.info_tables().bgm_info(self.bgm_data_id);
 
         let audio = context

--- a/shin/src/asset/mod.rs
+++ b/shin/src/asset/mod.rs
@@ -2,11 +2,11 @@ mod audio;
 pub mod bustup;
 mod font;
 mod locate;
+pub mod movie;
 pub mod picture;
 mod scenario;
 mod server;
 pub mod texture_archive;
-pub mod movie;
 
 pub mod asset_paths {
     pub const SCENARIO: &str = "/main.snr";

--- a/shin/src/layer/mod.rs
+++ b/shin/src/layer/mod.rs
@@ -262,9 +262,9 @@ impl UserLayer {
             }
             LayerType::Picture => {
                 let [pic_id, _, _, _, _, _, _, _] = params;
-                let pic_info @ PictureInfoItem { name, unk1 } =
+                let pic_info @ PictureInfoItem { name, linked_cg_id } =
                     scenario.info_tables().picture_info(pic_id);
-                debug!("Load picture: {} -> {} {}", pic_id, name, unk1);
+                debug!("Load picture: {} -> {} {}", pic_id, name, linked_cg_id);
                 let pic = asset_server
                     .load::<Picture, _>(pic_info.path())
                     .await
@@ -276,9 +276,12 @@ impl UserLayer {
                 let bup_info @ BustupInfoItem {
                     name,
                     emotion,
-                    unk1,
+                    lipsync_character_id,
                 } = scenario.info_tables().bustup_info(bup_id);
-                debug!("Load bustup: {} -> {} {} {}", bup_id, name, emotion, unk1);
+                debug!(
+                    "Load bustup: {} -> {} {} {}",
+                    bup_id, name, emotion, lipsync_character_id
+                );
                 let bup = asset_server
                     .load::<Bustup, _>(bup_info.path())
                     .await
@@ -290,13 +293,13 @@ impl UserLayer {
                 let [movie_id, _volume, _flags, _, _, _, _, _] = params;
                 let movie_info @ MovieInfoItem {
                     name,
-                    unk1,
-                    unk2,
-                    unk3,
+                    linked_picture_id,
+                    flags,
+                    linked_bgm_id,
                 } = scenario.info_tables().movie_info(movie_id);
                 debug!(
                     "Load movie: {} -> {} {} {} {}",
-                    movie_id, name, unk1, unk2, unk3
+                    movie_id, name, linked_picture_id, flags, linked_bgm_id
                 );
                 let movie = asset_server
                     .load::<Movie, _>(movie_info.path())


### PR DESCRIPTION
Primarily, I've added parsing logic for the `offset_72` (`bupmode` data), `offset_76` (`chars` sprites and descriptions), and `offset_80` (`chars` selection grids) info tables. These don't use static structs like the other info tables, but instead variable length "segments" akin to instructions in the main script. I've called them "segments" in the code too based on the terminology I used for kaleido a long time ago; if you'd prefer a different name let me know. Also let me know if you'd like any of the parsing code restructured, this is the first time actually using `binrw` and I might have missed some features that make everything more elegant 😅 

I've also renamed many of the existing `unk*` fields to more descriptive names, and added a bunch of documentation comments where appropriate.



